### PR TITLE
Fix README example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ result = sim.simulate_pattern(
     az_step=10.0,
 )
 impedance = result['impedance']  # (R, X)
-pattern = result['pattern']      # list of {{'el', 'az', 'gain'}}
-``` 
+pattern = result['pattern']      # list of {'el', 'az', 'gain'}
+```
 
 ### Key API
 


### PR DESCRIPTION
## Summary
- fix braces in README example so the list is rendered properly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6844613ca9588327b651ed36b6423483